### PR TITLE
fix: nameが日本語の場合memberページに遷移できないのを修正

### DIFF
--- a/members.ts
+++ b/members.ts
@@ -2,6 +2,7 @@ import { Member } from "@src/types";
 
 export const members: Member[] = [
   {
+    id: "catnose",
     name: "CatNose",
     role: "CTO",
     bio:
@@ -17,6 +18,7 @@ export const members: Member[] = [
     websiteUrl: "https://catnose99.com",
   },
   {
+    id: "john_doe",
     name: "John Doe",
     role: "SRE",
     bio: "Site Reliability Engineer.",
@@ -26,6 +28,7 @@ export const members: Member[] = [
     twitterUsername: "catnose99",
   },
   {
+    id: "amanda",
     name: "Amanda",
     role: "Frontend dev",
     bio: "Frontend developer,",
@@ -34,6 +37,7 @@ export const members: Member[] = [
     twitterUsername: "catnose99",
   },
   {
+    id: "takada_junji",
     name: "Takada Junji",
     role: "Designer",
     bio: "Designing all of the apps in Foo company.",
@@ -41,13 +45,15 @@ export const members: Member[] = [
     sources: [],
   },
   {
-    name: "Ota Naoko",
+    id: "ota_naoko",
+    name: "太田 直子",
     role: "Researcher",
     bio: "Some texts here",
     avatarSrc: "/avatars/naoko.jpg",
     sources: [],
   },
   {
+    id: "alexandria",
     name: "Alexandria",
     role: "Tech Lead",
     bio: "IT professional with 3 years of experience",

--- a/src/builder/posts.ts
+++ b/src/builder/posts.ts
@@ -44,7 +44,7 @@ async function getFeedItemsFromSources(sources: undefined | string[]) {
 }
 
 async function getMemberFeedItems(member: Member): Promise<PostItem[]> {
-  const { sources, name, includeUrlRegex, excludeUrlRegex } = member;
+  const { id, sources, name, includeUrlRegex, excludeUrlRegex } = member;
   const feedItems = await getFeedItemsFromSources(sources);
   if (!feedItems) return [];
 
@@ -52,6 +52,7 @@ async function getMemberFeedItems(member: Member): Promise<PostItem[]> {
     return {
       ...item,
       authorName: name,
+      authorId: id,
     };
   });
   // remove items which not matches includeUrlRegex

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -9,20 +9,21 @@ import {
   getHostFromURL,
   getFaviconSrcFromHostname,
   getMemberPath,
+  getMemberById,
 } from "@src/utils/helper";
 
 dayjs.extend(relativeTime);
 
 const PostLink: React.FC<{ item: PostItem }> = (props) => {
-  const { authorName, title, isoDate, link, dateMiliSeconds } = props.item;
-  const member = getMemberByName(authorName);
+  const { authorId, title, isoDate, link, dateMiliSeconds } = props.item;
+  const member = getMemberById(authorId);
   if (!member) return null;
 
   const hostname = getHostFromURL(link);
 
   return (
     <article className="post-link">
-      <Link href={getMemberPath(member.name)} passHref>
+      <Link href={getMemberPath(member.id)} passHref>
         <a className="post-link__author">
           <img
             src={member.avatarSrc}

--- a/src/components/ScrollableMembers.tsx
+++ b/src/components/ScrollableMembers.tsx
@@ -8,7 +8,7 @@ export const ScrollableMembers: React.FC = () => {
       {members.map((member, i) => (
         <Link
           key={`scrollable-member-${i}`}
-          href={getMemberPath(member.name)}
+          href={getMemberPath(member.id)}
           passHref
         >
           <a className="scrollable-member__link">

--- a/src/pages/members/[id].tsx
+++ b/src/pages/members/[id].tsx
@@ -5,8 +5,8 @@ import { PostList } from "@src/components/PostList";
 import { ContentWrapper } from "@src/components/ContentWrapper";
 import { PageSEO } from "@src/components/PageSEO";
 import {
-  getMemberByName,
-  getMemberPostsByName,
+  getMemberById,
+  getMemberPostsById,
   getMemberPath,
 } from "@src/utils/helper";
 
@@ -17,6 +17,7 @@ type Props = {
 
 const Page: NextPage<Props> = (props) => {
   const {
+    id,
     name,
     bio,
     avatarSrc,
@@ -27,7 +28,7 @@ const Page: NextPage<Props> = (props) => {
 
   return (
     <>
-      <PageSEO title={name} path={getMemberPath(name)} />
+      <PageSEO title={name} path={getMemberPath(id)} />
       <section className="member">
         <ContentWrapper>
           <header className="member-header">
@@ -92,9 +93,9 @@ const Page: NextPage<Props> = (props) => {
 };
 
 export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
-  const name = params?.name as string;
-  const member = getMemberByName(name);
-  const postItems = getMemberPostsByName(name);
+  const id = params?.id as string;
+  const member = getMemberById(id);
+  const postItems = getMemberPostsById(id);
 
   if (!member) throw "User not found";
 
@@ -107,13 +108,11 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const memberNameList = members.map((member) =>
-    encodeURIComponent(member.name)
-  );
-  const paths = memberNameList.map((name) => {
+  const memberNameList = members.map((member) => encodeURIComponent(member.id));
+  const paths = memberNameList.map((id) => {
     return {
       params: {
-        name,
+        id,
       },
     };
   });

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -11,7 +11,7 @@ import { Member } from "@src/types";
 
 const MemberCard: React.FC<{ member: Member }> = ({ member }) => {
   return (
-    <Link href={getMemberPath(member.name)}>
+    <Link href={getMemberPath(member.id)}>
       <a className="member-card">
         <div className="member-card__avatar">
           <img

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type Member = {
+  id: string;
   name: string;
   avatarSrc: string;
   role?: string;
@@ -12,6 +13,7 @@ export type Member = {
 };
 
 export type PostItem = {
+  authorId: string;
   authorName: string;
   title: string;
   link: string;

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -5,8 +5,13 @@ import posts from "@.contents/posts.json";
 export function getMemberByName(name: string) {
   return members.find((member) => member.name === name);
 }
-export function getMemberPostsByName(name: string) {
-  return (posts as PostItem[]).filter((item) => item.authorName === name);
+
+export function getMemberById(id: string) {
+  return members.find((member) => member.id === id);
+}
+
+export function getMemberPostsById(id: string) {
+  return (posts as PostItem[]).filter((item) => item.authorId === id);
 }
 export function getHostFromURL(str: string) {
   const url = new URL(str);
@@ -15,6 +20,6 @@ export function getHostFromURL(str: string) {
 export function getFaviconSrcFromHostname(hostname: string) {
   return `https://www.google.com/s2/favicons?domain=${hostname}`;
 }
-export function getMemberPath(name: string) {
-  return `/members/${encodeURIComponent(name)}`;
+export function getMemberPath(id: string) {
+  return `/members/${encodeURIComponent(id)}`;
 }


### PR DESCRIPTION
nameに日本語を使用すると、静的ページを吐き出した際にリンク切れになってしまうという問題がありました。
nameに日本語を使いたいという需要は一定ありそうなため、idというkeyを追加してみました。