### PR TITLE
A link of post opens in a new tab

### DIFF
--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -38,7 +38,12 @@ const PostLink: React.FC<{ item: PostItem }> = (props) => {
           </div>
         </a>
       </Link>
-      <a href={link} className="post-link__main-link">
+      <a
+        href={link}
+        className="post-link__main-link"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
         <h2 className="post-link__title">{title}</h2>
         {hostname && (
           <div className="post-link__site">


### PR DESCRIPTION
blog hubに載る記事はblog hubとは異なるドメインであることがほとんどです。

そのため、blog hub自体の回遊性を上げるために、記事は新しいタブで開くのが良いと考えました。


